### PR TITLE
Minor changes to my recipes

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -207,8 +207,8 @@ sun-defas-departures:
     repo: 'https://forgejo.sny.sh/sun/TRMNL/src/branch/main/recipes/defas-departures'
     zip_url: 'https://forgejo.sny.sh/sun/TRMNL/archive/main:recipes/defas-departures.zip'
     version: main
-  logo_url: null
-  screenshot_url: null
+  logo_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/icons/defas-departures.svg'
+  screenshot_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/previews/defas-departures.png'
   license: Unlicense
   byos:
     byos_laravel:
@@ -232,8 +232,8 @@ sun-film-guide:
     repo: 'https://forgejo.sny.sh/sun/TRMNL/src/branch/main/recipes/film-guide'
     zip_url: 'https://forgejo.sny.sh/sun/TRMNL/archive/main:recipes/film-guide.zip'
     version: main
-  logo_url: 'https://trmnl-public.s3.us-east-2.amazonaws.com/o8jjf4q5m62lmlqrwtwk7fg7vy6f'
-  screenshot_url: null
+  logo_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/icons/film-guide.svg'
+  screenshot_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/previews/film-guide.png'
   license: Unlicense
   byos:
     byos_laravel:
@@ -257,8 +257,8 @@ sun-weather-graph:
     repo: 'https://forgejo.sny.sh/sun/TRMNL/src/branch/main/recipes/weather-graph'
     zip_url: 'https://forgejo.sny.sh/sun/TRMNL/archive/main:recipes/weather-graph.zip'
     version: main
-  logo_url: 'https://trmnl-public.s3.us-east-2.amazonaws.com/jxxda714yzei5v3wm1u1q9rj0i0t'
-  screenshot_url: null
+  logo_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/icons/weather-graph.svg'
+  screenshot_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/previews/weather-graph.png'
   license: Unlicense
   byos:
     byos_laravel:

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -218,7 +218,8 @@ sun-defas-departures:
   author:
     github: TheLastZombie
     name: Sunny
-  funding: {  }
+  funding:
+    liberapay: sun
   author_bio:
     name: Sunny
     description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'
@@ -243,7 +244,8 @@ sun-film-guide:
   author:
     github: TheLastZombie
     name: Sunny
-  funding: {  }
+  funding:
+    liberapay: sun
   author_bio:
     name: Sunny
     description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'
@@ -268,7 +270,8 @@ sun-weather-graph:
   author:
     github: TheLastZombie
     name: Sunny
-  funding: {  }
+  funding:
+    liberapay: sun
   author_bio:
     name: Sunny
     description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -252,6 +252,32 @@ sun-film-guide:
     github_url: 'https://github.com/TheLastZombie'
     learn_more_url: 'https://sny.sh/'
     email_address: sunny@sny.sh
+sun-toki-pona:
+  name: 'Random Toki Pona Word'
+  trmnlp:
+    id: 137228
+    repo: 'https://forgejo.sny.sh/sun/TRMNL/src/branch/main/recipes/toki-pona'
+    zip_url: 'https://forgejo.sny.sh/sun/TRMNL/archive/main:recipes/toki-pona.zip'
+    version: main
+  logo_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/icons/toki-pona.svg'
+  screenshot_url: 'https://forgejo.sny.sh/sun/TRMNL/raw/branch/main/previews/toki-pona.png'
+  license: Unlicense
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: 0.13.0
+  author:
+    github: TheLastZombie
+    name: Sunny
+  funding:
+    liberapay: sun
+  author_bio:
+    name: Sunny
+    description: 'Professional programmer and designer, among other things.<br>This recipe displays a random Toki Pona word along with its definition.'
+    github_url: 'https://github.com/TheLastZombie'
+    learn_more_url: 'https://sny.sh/'
+    email_address: sunny@sny.sh
 sun-weather-graph:
   name: 'Temperature Graph'
   trmnlp:

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -222,7 +222,7 @@ sun-defas-departures:
     liberapay: sun
   author_bio:
     name: Sunny
-    description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'
+    description: 'Displays the next departures for stops in Bavaria using the EFA API.'
     github_url: 'https://github.com/TheLastZombie'
     learn_more_url: 'https://sny.sh/'
     email_address: sunny@sny.sh
@@ -248,7 +248,7 @@ sun-film-guide:
     liberapay: sun
   author_bio:
     name: Sunny
-    description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'
+    description: 'Displays the next departures for stops in Bavaria using the EFA API.'
     github_url: 'https://github.com/TheLastZombie'
     learn_more_url: 'https://sny.sh/'
     email_address: sunny@sny.sh
@@ -274,7 +274,7 @@ sun-toki-pona:
     liberapay: sun
   author_bio:
     name: Sunny
-    description: 'Professional programmer and designer, among other things.<br>This recipe displays a random Toki Pona word along with its definition.'
+    description: 'Displays a random Toki Pona word along with its definition.'
     github_url: 'https://github.com/TheLastZombie'
     learn_more_url: 'https://sny.sh/'
     email_address: sunny@sny.sh
@@ -300,7 +300,7 @@ sun-weather-graph:
     liberapay: sun
   author_bio:
     name: Sunny
-    description: 'Professional programmer and designer, among other things.<br>This recipe displays the next departures for stops in Bavaria using the EFA API.'
+    description: 'Displays the next departures for stops in Bavaria using the EFA API.'
     github_url: 'https://github.com/TheLastZombie'
     learn_more_url: 'https://sny.sh/'
     email_address: sunny@sny.sh


### PR DESCRIPTION
Hi, thanks for adding my recipes to the catalog already! I made some minor changes, if you don't mind:

- I updated the logo URLs so that they point to my own server, making them independent of the TRMNL infrastructure and allowing a logo to be displayed for the (not yet published) DEFAS Departures recipe.
  - If the `trmnl-public.s3.us-east-2.amazonaws.com` URLs were chosen on purpose because they serve PNG instead of SVG, let me know and I can add PNGs to the repository as well.
- I added screenshot URLs for all of my recipes.
- I added funding information.
  - I use Liberapay as the only platform, so this adds a new `liberapay` property for that in the same vein as `github` and `buy_me_a_coffee`. The URL can then be constructed similar to the others as `https://liberapay.com/{value}`, i. e. `sun` → `https://liberapay.com/sun`.
- I added my Random Toki Pona Word recipe.
- I shortened the descriptions to remove the repeating first paragraph and work around BYOS Laravel escaping HTML tags.