### PR TITLE
Add 5 recipes: Plex Watchlist, Plex Server recently-added, WMATA Bethesda bus board

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -186,6 +186,116 @@ andi4000-trmnl-open-meteo-weather-forecast:
     description: |
       Hourly weather forecast plugin with Open-Meteo Backend. No API key required. NOTE: Click save right after plugin import, to populate the required fields to fetch the weather data. Otherwise you will get "Liquid error" messages. Report bugs and translation issues on GitHub link below.
     github_url: 'https://github.com/andi4000/trmnl-open-meteo-weather-forecast'
+andremessier-trmnl-recipes-plex-watchlist-movies:
+  name: 'Plex Watchlist - Recent Movies'
+  trmnlp:
+    repo: 'https://github.com/AndreMessier/trmnl-recipes'
+    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
+    zip_entry_path: trmnl-recipes-main/plex-watchlist-movies
+    version: main
+  logo_url: null
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/plex-watchlist-movies.png'
+  license: MIT
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: null
+  author:
+    github: AndreMessier
+    name: 'Andre Messier'
+  funding: {  }
+  author_bio:
+    description: 'Shows your Plex Watchlist movies, sorted by release date (newest first). Requires a personal Plex token.'
+    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
+andremessier-trmnl-recipes-plex-watchlist-episodes:
+  name: 'Plex Watchlist - Recent Episodes'
+  trmnlp:
+    repo: 'https://github.com/AndreMessier/trmnl-recipes'
+    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
+    zip_entry_path: trmnl-recipes-main/plex-watchlist-episodes
+    version: main
+  logo_url: null
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/plex-watchlist-episodes.png'
+  license: MIT
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: null
+  author:
+    github: AndreMessier
+    name: 'Andre Messier'
+  funding: {  }
+  author_bio:
+    description: 'Shows your Plex Watchlist TV shows, sorted by most recent episode air date rather than premiere date. Excludes anything more than 3 days in the future. Requires a personal Plex token.'
+    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
+andremessier-trmnl-recipes-plex-server-new-movies:
+  name: 'Plex Server - Recently Added Movies'
+  trmnlp:
+    repo: 'https://github.com/AndreMessier/trmnl-recipes'
+    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
+    zip_entry_path: trmnl-recipes-main/plex-server-new-movies
+    version: main
+  logo_url: null
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/plex-server-new-movies.png'
+  license: MIT
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: null
+  author:
+    github: AndreMessier
+    name: 'Andre Messier'
+  funding: {  }
+  author_bio:
+    description: 'Recently added movies on your own Plex Media Server. Requires your Plex token and server URL.'
+    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
+andremessier-trmnl-recipes-plex-server-new-episodes:
+  name: 'Plex Server - Recently Added Episodes'
+  trmnlp:
+    repo: 'https://github.com/AndreMessier/trmnl-recipes'
+    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
+    zip_entry_path: trmnl-recipes-main/plex-server-new-episodes
+    version: main
+  logo_url: null
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/plex-server-new-episodes.png'
+  license: MIT
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: null
+  author:
+    github: AndreMessier
+    name: 'Andre Messier'
+  funding: {  }
+  author_bio:
+    description: 'Recently added TV episodes on your own Plex Media Server, aggregated by show rather than one row per episode. Requires your Plex token and server URL.'
+    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
+andremessier-trmnl-recipes-wmata-bethesda-bus:
+  name: 'WMATA Bethesda Station Bus Board'
+  trmnlp:
+    repo: 'https://github.com/AndreMessier/trmnl-recipes'
+    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
+    zip_entry_path: trmnl-recipes-main/wmata-bethesda-bus
+    version: main
+  logo_url: null
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/wmata-bethesda-bus.png'
+  license: MIT
+  byos:
+    byos_laravel:
+      compatibility: true
+      compatibility_note: null
+      min_version: null
+  author:
+    github: AndreMessier
+    name: 'Andre Messier'
+  funding: {  }
+  author_bio:
+    description: 'Combined bus arrival board for all three Metrobus routes serving Bethesda Station (D96, M22, M70). Requires a free WMATA developer API key.'
+    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andrzejskowron-steamsales:
   name: 'Steam Sales'
   trmnlp:

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -228,7 +228,7 @@ andremessier-trmnl-recipes-plex-watchlist-episodes:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
-    description: 'Shows your Plex Watchlist TV shows, sorted by most recent episode air date rather than premiere date. Excludes anything more than 3 days in the future. Requires a personal Plex token.'
+    description: 'Shows your Plex Watchlist TV shows, sorted by most recent episode air date rather than premiere date. Excludes anything more than N days in the future (configurable, default 3). Requires a personal Plex token.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-plex-server-new-movies:
   name: 'Plex Server - Recently Added Movies'


### PR DESCRIPTION
Adds 5 new recipes from [AndreMessier/trmnl-recipes](https://github.com/AndreMessier/trmnl-recipes):

- **Plex Watchlist – Recent Movies** — watchlist movies sorted by release date
- **Plex Watchlist – Recent Episodes** — watchlist shows sorted by most recent *episode* air date rather than premiere date (Plex's API doesn't support this sort server-side, handled client-side in Liquid), excludes anything more than 3 days in the future
- **Plex Server – Recently Added Movies** — recently added on your own Plex Media Server
- **Plex Server – Recently Added Episodes** — recently added on your own PMS, aggregated by show rather than one row per episode
- **WMATA Bethesda Station Bus Board** — combines all three Metrobus routes serving Bethesda Station (across three separate stop IDs / bus bays) into one sorted arrival board

All built and tested against live data on a self-hosted LaraPaper instance. MIT licensed.