### PR TITLE
Update WMATA Bethesda Station Bus Board -> WMATA Bus (generalized)

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -279,7 +279,7 @@ andremessier-trmnl-recipes-plex-watchlist-movies:
     description: 'Shows your Plex Watchlist movies, sorted by release date (newest first). Requires a personal Plex token.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-wmata-bethesda-bus:
-  name: 'WMATA Bethesda Station Bus Board'
+  name: 'WMATA Bus'
   trmnlp:
     repo: 'https://github.com/AndreMessier/trmnl-recipes'
     zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
@@ -299,7 +299,7 @@ andremessier-trmnl-recipes-wmata-bethesda-bus:
   funding: {  }
   author_bio:
     category: 'travel,life'
-    description: 'Combined bus arrival board for all three Metrobus routes serving Bethesda Station (D96, M22, M70). Requires a free WMATA developer API key.'
+    description: 'Combined bus arrival board for any set of WMATA bus stops, merged and sorted by arrival time. Configure a comma-separated list of StopIDs (any number, including just one). Originally built for the three Metrobus routes/bays at Bethesda Station (D96, M22, M70), which remains the default example. Requires a free WMATA developer API key.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andrzejskowron-steamsales:
   name: 'Steam Sales'

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -281,12 +281,12 @@ andremessier-trmnl-recipes-plex-watchlist-movies:
 andremessier-trmnl-recipes-wmata-bethesda-bus:
   name: 'WMATA Bus'
   trmnlp:
-    repo: 'https://github.com/AndreMessier/trmnl-recipes'
-    zip_url: 'https://github.com/AndreMessier/trmnl-recipes/archive/refs/heads/main.zip'
-    zip_entry_path: trmnl-recipes-main/wmata-bethesda-bus
+    repo: 'https://github.com/AndreMessier/trmnl-wmata-bus'
+    zip_url: 'https://github.com/AndreMessier/trmnl-wmata-bus/archive/refs/heads/main.zip'
+    zip_entry_path: null
     version: main
   logo_url: null
-  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-recipes/main/screenshots/wmata-bethesda-bus.png'
+  screenshot_url: 'https://raw.githubusercontent.com/AndreMessier/trmnl-wmata-bus/main/screenshots/wmata-bus.png'
   license: MIT
   byos:
     byos_laravel:
@@ -300,7 +300,7 @@ andremessier-trmnl-recipes-wmata-bethesda-bus:
   author_bio:
     category: 'travel,life'
     description: 'Combined bus arrival board for any set of WMATA bus stops, merged and sorted by arrival time. Configure a comma-separated list of StopIDs (any number, including just one). Originally built for the three Metrobus routes/bays at Bethesda Station (D96, M22, M70), which remains the default example. Requires a free WMATA developer API key.'
-    github_url: 'https://github.com/AndreMessier/trmnl-recipes'
+    github_url: 'https://github.com/AndreMessier/trmnl-wmata-bus'
 andrzejskowron-steamsales:
   name: 'Steam Sales'
   trmnlp:


### PR DESCRIPTION
Small follow-up to #19. The underlying recipe at [AndreMessier/trmnl-recipes](https://github.com/AndreMessier/trmnl-recipes) was generalized since that PR merged: it now accepts any comma-separated list of WMATA bus StopIDs (any count, including just one) instead of being hardcoded to the three Bethesda Station bays.

This updates the catalog's display name and description to match the new "WMATA Bus" recipe name. The repo path (`wmata-bethesda-bus`) and catalog key are left unchanged since installs already reference that exact `zip_entry_path`.