### PR TITLE
Add category metadata to 5 recipes from #19

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -206,6 +206,7 @@ andremessier-trmnl-recipes-plex-server-new-episodes:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
+    category: entertainment
     description: 'Recently added TV episodes on your own Plex Media Server, aggregated by show rather than one row per episode. Requires your Plex token and server URL.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-plex-server-new-movies:
@@ -228,6 +229,7 @@ andremessier-trmnl-recipes-plex-server-new-movies:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
+    category: entertainment
     description: 'Recently added movies on your own Plex Media Server. Requires your Plex token and server URL.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-plex-watchlist-episodes:
@@ -250,6 +252,7 @@ andremessier-trmnl-recipes-plex-watchlist-episodes:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
+    category: entertainment
     description: 'Shows your Plex Watchlist TV shows, sorted by most recent episode air date rather than premiere date. Excludes anything more than N days in the future (configurable, default 3). Requires a personal Plex token.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-plex-watchlist-movies:
@@ -272,6 +275,7 @@ andremessier-trmnl-recipes-plex-watchlist-movies:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
+    category: entertainment
     description: 'Shows your Plex Watchlist movies, sorted by release date (newest first). Requires a personal Plex token.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andremessier-trmnl-recipes-wmata-bethesda-bus:
@@ -294,6 +298,7 @@ andremessier-trmnl-recipes-wmata-bethesda-bus:
     name: 'Andre Messier'
   funding: {  }
   author_bio:
+    category: 'travel,life'
     description: 'Combined bus arrival board for all three Metrobus routes serving Bethesda Station (D96, M22, M70). Requires a free WMATA developer API key.'
     github_url: 'https://github.com/AndreMessier/trmnl-recipes'
 andrzejskowron-steamsales:


### PR DESCRIPTION
Follow-up to #19 — the 5 recipes added there were missing the `category` field under `author_bio`, so none of them show up in the catalog site's category filters (e.g. the WMATA board isn't listed under Travel).

- **WMATA Bethesda Station Bus Board** → `travel,life` (same categories as the existing TransLink departures plugin)
- **Plex Watchlist – Recent Movies** → `entertainment`
- **Plex Watchlist – Recent Episodes** → `entertainment`
- **Plex Server – Recently Added Movies** → `entertainment`
- **Plex Server – Recently Added Episodes** → `entertainment`

No other changes.